### PR TITLE
chore(project): ajouter conventions de commit, intégration GitHub et …

### DIFF
--- a/.claude/skills/bmad-code-review/steps/step-04-present.md
+++ b/.claude/skills/bmad-code-review/steps/step-04-present.md
@@ -107,6 +107,22 @@ If `{sprint_status}` file exists:
 
 If `{sprint_status}` file does not exist, note that story status was updated in the story file only.
 
+#### Close GitHub issue when done
+
+If `{new_status}` = `done` AND `{story_key}` is set:
+
+1. Extract the story number from `{story_key}` (e.g., `1-3-reflectresolver-...` → epic `1`, story `3`).
+2. Search for the corresponding GitHub issue:
+   ```bash
+   gh issue list --repo enokdev/helix --search "Story 1.3" --json number,title --limit 5
+   ```
+3. If a matching issue is found, close it with a comment:
+   ```bash
+   gh issue close <number> --repo enokdev/helix --comment "Story implémentée et validée. ✅"
+   ```
+   Closing the issue automatically updates the linked task in the GitHub Project `https://github.com/orgs/enokdev/projects/1`.
+4. If no matching issue is found, warn the user but do not block.
+
 #### Completion summary
 
 > **Review Complete!**

--- a/.claude/skills/bmad-dev-story/workflow.md
+++ b/.claude/skills/bmad-dev-story/workflow.md
@@ -360,6 +360,12 @@ Load config from `{project-root}/_bmad/bmm/config.yaml` and resolve:
   </step>
 
   <step n="9" goal="Story completion and mark for review" tag="sprint-status">
+    <critical>COMMIT FORMAT: Use conventional commits WITHOUT Co-Authored-By trailer.
+      Format: `type(scope): description`
+      Examples: `feat(core): implémenter ReflectResolver`, `fix(web): corriger routing DELETE`
+      Types: feat, fix, test, refactor, docs, chore, perf
+      Scopes: core, web, data, config, starter, observability, scheduler, cli
+    </critical>
     <action>Verify ALL tasks and subtasks are marked [x] (re-scan the story document now)</action>
     <action>Run the full regression suite (do not skip)</action>
     <action>Confirm File List includes every changed file</action>

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,97 @@
+# Helix — Copilot Instructions
+
+## Project Status
+
+Helix is currently in the **pre-code / planning phase**. Only `prd.md` (the product requirements document, written in French) exists as source of truth. No Go source files exist yet. All architecture described below is planned, not yet implemented.
+
+## What Helix Is
+
+A Go backend framework inspired by Spring Boot, built on [Fiber](https://gofiber.io/). It brings DI/IoC, auto-configuration, a repository pattern, observability endpoints, and a CLI to idiomatic Go — without sacrificing Go's performance or explicitness.
+
+## Planned Package Layout
+
+```
+helix/
+ ├── core/           # DI container, lifecycle management
+ ├── web/            # Fiber HTTP integration, routing, middleware
+ ├── data/           # Repository pattern, ORM adapters (GORM → Ent → sqlc)
+ ├── config/         # YAML/JSON/TOML/ENV loader
+ ├── starter/        # Auto-configuration modules
+ ├── observability/  # Prometheus metrics, slog, OpenTelemetry
+ └── cli/            # `helix new`, `helix generate`, `helix run`
+```
+
+## Core Design Principles
+
+- **Struct tags over annotations** — use `inject:"true"` tags for DI, `mapstructure:"key"` for config mapping
+- **Compile-time over runtime** — code generation (Wire-like) is the default DI mode; reflection is opt-in and the two modes are **mutually exclusive per module**
+- **No global state** — explicit dependency wiring throughout
+- **Config resolution order**: `ENV > YAML > DEFAULT`
+- **Starter activation**: a starter is active only if its dependency is present in `go.mod` AND its minimum config key is provided
+
+## Key Interfaces (as specified in the PRD)
+
+```go
+// DI container
+container := helix.NewContainer()
+container.Register(UserRepositoryImpl{})
+container.Resolve(&UserService{})
+
+// Repository — ID is parameterized (int, int64, string, uuid.UUID, or any comparable)
+type Repository[T any, ID any] interface {
+    FindAll() ([]T, error)
+    FindByID(id ID) (*T, error)
+    FindWhere(filter Filter) ([]T, error)
+    Save(entity *T) error
+    Delete(id ID) error
+    Paginate(page, size int) (Page[T], error)
+    WithTransaction(tx Transaction) Repository[T, ID]
+}
+
+// Lifecycle hooks (called in reverse dependency order on shutdown)
+type Lifecycle interface {
+    OnStart() error
+    OnStop() error
+}
+
+// Config reload callback for singleton components
+type ConfigReloadable interface {
+    OnConfigReload()
+}
+```
+
+## Go Commands (once code exists)
+
+```bash
+go mod tidy          # install/sync dependencies
+go build ./...       # build all packages
+go test ./...        # run all tests
+go test ./core/...   # run tests for a single package
+go test -run TestName ./core/...  # run a single test
+go test -cover ./core/...         # coverage (target: >80% on core/)
+```
+
+Minimum Go version: **1.21** (required for `slog`).
+
+## Observability Endpoints
+
+Every Helix application exposes:
+- `GET /health` — app + dependency health
+- `GET /metrics` — Prometheus metrics
+- `GET /info` — version, build info, active config
+
+## Roadmap Phases
+
+| Phase | Gate condition |
+|-------|---------------|
+| 1 — MVP | CRUD API running with DI, YAML config, Fiber |
+| 2 — Structure | Project maintainable/extensible without touching `core/` |
+| 3 — Production | Full observability, security (JWT/RBAC), CLI |
+| 4 — Ecosystem | Cloud modules (Consul, circuit breaker), Ent/sqlc, plugins |
+
+## Out of Scope
+
+- gRPC / WebSocket (Phase 1–2)
+- Frontend / SSR
+- Custom ORM — Helix wraps GORM, Ent, or sqlc
+- Multi-language support

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,74 @@
+# AGENTS.md
+
+## Project State
+
+Helix is in **pre-code / planning phase**. No Go source files exist yet. The PRD (`prd.md`) and all planning artifacts in `_bmad-output/` are written in **French**.
+
+The next implementation step is Story 1.1 (project scaffold): `_bmad-output/implementation-artifacts/1-1-initialisation-du-projet-structure-de-base.md`
+
+## Source of Truth
+
+- **PRD**: `prd.md` (French) — product requirements
+- **Architecture**: `_bmad-output/planning-artifacts/architecture.md` — all technical decisions
+- **Epics & Stories**: `_bmad-output/planning-artifacts/epics.md` — full backlog
+- **Sprint Status**: `_bmad-output/implementation-artifacts/sprint-status.yaml` — current progress
+- **Story Specs**: `_bmad-output/implementation-artifacts/*.md` — detailed story files with acceptance criteria
+
+When architecture docs conflict with `prd.md`, the architecture doc takes precedence (it was derived from the PRD and refined).
+
+## Go Module & Tooling
+
+- Module: `github.com/enokdev/helix`
+- Minimum Go: **1.21** (required for `slog` and stable generics)
+- Linting: `golangci-lint` with vet, staticcheck, errcheck, gofumpt
+- Formatting: `gofumpt` (not just `gofmt`)
+- Testing: `go test ./...` + `testify/assert` + `testify/mock`
+- CI: GitHub Actions — lint, test, build on push/PR; goreleaser on `v*` tags
+
+## Commands
+
+```bash
+go build ./...                        # build all packages
+go test ./...                         # run all tests
+go test ./core/...                    # single package
+go test -run TestName ./core/...      # single test
+golangci-lint run                     # lint (must pass before commit)
+```
+
+## Package Rules
+
+Strict import hierarchy — violations will cause circular dependencies:
+- `core/` — **zero imports** of other Helix packages
+- `config/` — **zero imports** of other Helix packages
+- `web/internal/` — only place allowed to import `gofiber/fiber`
+- Public interfaces go in package root files (e.g. `core/container.go`)
+- Private implementations go in `internal/` subdirectories
+
+Package naming: lowercase, singular, no underscores or dashes (`core`, `config`, `web`, `data`, `testutil`).
+
+## DI Architecture
+
+Two mutually exclusive resolver modes behind a shared `Resolver` interface:
+- **ReflectResolver** (default) — runtime reflection, used for development
+- **WireResolver** (opt-in) — compile-time codegen, used for production
+
+A module uses one mode, never both. The `Container` delegates to whichever `Resolver` is configured.
+
+## Key Conventions
+
+- DI via struct tags: `inject:"true"` — not constructor injection
+- Config mapping via: `mapstructure:"key"` and `value:"key"`
+- Component discovery via struct embeds: `helix.Service`, `helix.Controller`, `helix.Repository`, `helix.Component`
+- Code generation directives: `//helix:route`, `//helix:transactional`, `//helix:scheduled`, `//helix:guard`
+- Config priority: `ENV > YAML profile > application.yaml > DEFAULT`
+- Observability endpoints under `/actuator/` (not root): `/actuator/health`, `/actuator/metrics`, `/actuator/info`
+
+## BMad Methodology
+
+This repo uses BMad for planning. Skills are installed in `.opencode/skills/`, `.agent/skills/`, `.github/skills/`, `.gemini/skills/`, `.agents/skills/`, and `.claude/skills/`. Planning output lives in `_bmad-output/`. Do not modify BMad skill files — they are tooling, not project code.
+
+## Performance Targets
+
+- Startup: < 100ms
+- P99 latency `/actuator/health`: < 5ms
+- Test coverage on `core/`: > 80%

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,3 +82,42 @@ go test ./core/...   # run tests for a specific package
 - **Phase 2**: Repository pattern, auto-configuration, lifecycle management
 - **Phase 3**: Observability, security module, CLI tool
 - **Phase 4**: Cloud/microservices modules (Consul service discovery, circuit breaker), plugin system
+
+## Commit Message Format
+
+**ALWAYS** use conventional commits format. **NEVER** add a `Co-Authored-By` line or any other trailer.
+
+Format: `<type>(<scope>): <description>`
+
+Examples:
+```
+feat(core): implémenter le conteneur DI avec ReflectResolver
+fix(web): corriger le routing par convention pour les méthodes DELETE
+test(data): ajouter les tests d'intégration pour GormRepository
+refactor(config): extraire la logique de priorité ENV > YAML > DEFAULT
+```
+
+Types: `feat`, `fix`, `test`, `refactor`, `docs`, `chore`, `perf`
+Scopes: `core`, `web`, `data`, `config`, `starter`, `observability`, `scheduler`, `cli`
+
+## GitHub Project Integration
+
+**Repository:** `enokdev/helix` — **Project:** `https://github.com/orgs/enokdev/projects/1`
+
+### When a story reaches `done` status
+
+When a story is marked `done` (either during code-review or manually), **always** execute the following:
+
+1. Find the corresponding GitHub issue by searching for the story number:
+   ```bash
+   gh issue list --repo enokdev/helix --search "Story <N>.<M>" --json number,title
+   ```
+2. Close the issue (this automatically closes the linked project task):
+   ```bash
+   gh issue close <number> --repo enokdev/helix --comment "Story implémentée et validée. ✅"
+   ```
+
+### Story → Issue mapping convention
+
+GitHub issues were created with titles following the pattern: `Story N.M — <titre>`.  
+Example: story key `1-3-reflectresolver-...` → search `"Story 1.3"` to find the issue number.

--- a/_bmad-output/implementation-artifacts/1-1-initialisation-du-projet-structure-de-base.md
+++ b/_bmad-output/implementation-artifacts/1-1-initialisation-du-projet-structure-de-base.md
@@ -1,0 +1,222 @@
+# Story 1.1: Initialisation du Projet & Structure de Base
+
+Status: ready-for-dev
+
+<!-- Note: Validation is optional. Run validate-create-story for quality check before dev-story. -->
+
+## Story
+
+En tant que **contributeur du framework**,
+Je veux initialiser le module Go Helix avec la structure de packages et l'outillage CI,
+Afin d'avoir une base solide sur laquelle construire le framework.
+
+## Acceptance Criteria
+
+1. **Given** un répertoire vide
+   **When** `go mod init github.com/enokdev/helix` est exécuté et les fichiers initiaux sont créés
+   **Then** le module compile avec `go build ./...` sans erreur
+
+2. **And** `golangci-lint run` passe sans erreur
+
+3. **And** `go test ./...` s'exécute (0 tests, 0 erreurs)
+
+4. **And** GitHub Actions CI tourne sur push et PR (lint + test + build)
+
+5. **And** la structure de dossiers suivante existe :
+   `core/`, `config/`, `web/`, `data/`, `testutil/`, `starter/`, `observability/`, `security/`, `scheduler/`, `cli/`, `examples/`
+
+## Tasks / Subtasks
+
+- [ ] Tâche 1 : Initialiser le module Go (AC: #1)
+  - [ ] Exécuter `go mod init github.com/enokdev/helix`
+  - [ ] Vérifier `go 1.21` dans `go.mod`
+  - [ ] Créer `go.sum` (vide à ce stade)
+
+- [ ] Tâche 2 : Créer la structure de packages (AC: #5)
+  - [ ] Créer `core/` avec fichier placeholder `doc.go` (package core)
+  - [ ] Créer `config/` avec fichier placeholder `doc.go` (package config)
+  - [ ] Créer `web/` avec fichier placeholder `doc.go` (package web)
+  - [ ] Créer `web/internal/` avec `doc.go` (package internal)
+  - [ ] Créer `data/` avec fichier placeholder `doc.go` (package data)
+  - [ ] Créer `data/gorm/` avec `doc.go` (package gorm)
+  - [ ] Créer `testutil/` avec fichier placeholder `doc.go` (package testutil)
+  - [ ] Créer `starter/` avec `doc.go` (package starter)
+  - [ ] Créer `observability/` avec `doc.go` (package observability)
+  - [ ] Créer `security/` avec `doc.go` (package security)
+  - [ ] Créer `scheduler/` avec `doc.go` (package scheduler)
+  - [ ] Créer `cli/` avec `doc.go` (package cli)
+  - [ ] Créer `examples/crud-api/` avec `main.go` vide
+  - [ ] Créer `helix.go` à la racine (package helix — marqueurs vides)
+
+- [ ] Tâche 3 : Configurer l'outillage de qualité (AC: #2, #3)
+  - [ ] Créer `.golangci.yml` avec les linters requis (vet, staticcheck, errcheck, gofumpt)
+  - [ ] Vérifier que `go build ./...` passe
+  - [ ] Vérifier que `go test ./...` s'exécute sans erreur
+
+- [ ] Tâche 4 : Créer le pipeline CI GitHub Actions (AC: #4)
+  - [ ] Créer `.github/workflows/ci.yml` (lint + test + build sur push et PR)
+  - [ ] Créer `.github/workflows/release.yml` (goreleaser sur tag `v*`)
+
+- [ ] Tâche 5 : Ajouter les fichiers racine du projet
+  - [ ] Créer `README.md` (titre + badges CI + instructions démarrage rapide)
+  - [ ] Créer `CONTRIBUTING.md`
+  - [ ] Créer `LICENSE` (MIT recommandé)
+  - [ ] Créer `.gitignore` (binaires Go, `.env`, `_bmad-output/`)
+
+## Dev Notes
+
+### Contexte Architectural
+
+Cette story est le **Sprint 0** — fondation sur laquelle tout le framework repose. Aucun code fonctionnel n'est attendu : uniquement la structure, le module et le CI.
+
+- **Module :** `github.com/enokdev/helix` (ou `github.com/{org}/helix` — utiliser `enokdev` par défaut)
+- **Go minimum :** `go 1.21` — obligatoire pour `slog` (stdlib) et generics stables
+- **Aucune dépendance externe** dans `go.mod` à ce stade — les dépendances (Fiber, GORM, Viper…) seront ajoutées dans les stories suivantes
+
+### Structure de Packages à Créer
+
+```
+helix/
+├── go.mod                          # module github.com/enokdev/helix, go 1.21
+├── go.sum
+├── helix.go                        # package helix — types marqueurs vides (Story 1.7)
+├── README.md
+├── CONTRIBUTING.md
+├── LICENSE
+├── .github/
+│   └── workflows/
+│       ├── ci.yml
+│       └── release.yml
+├── .golangci.yml
+├── core/
+│   └── doc.go                      # "Package core provides the DI container..."
+├── config/
+│   └── doc.go
+├── web/
+│   ├── doc.go
+│   └── internal/
+│       └── doc.go
+├── data/
+│   ├── doc.go
+│   └── gorm/
+│       └── doc.go
+├── testutil/
+│   └── doc.go
+├── starter/
+│   └── doc.go
+├── observability/
+│   └── doc.go
+├── security/
+│   └── doc.go
+├── scheduler/
+│   └── doc.go
+├── cli/
+│   └── doc.go
+└── examples/
+    └── crud-api/
+        └── main.go                 # package main vide
+```
+
+### Règles Critiques à Respecter
+
+**Naming des packages :**
+- Toujours minuscules, singulier, sans underscore ni tiret : `core`, `config`, `web`, `data`, `testutil` ✅
+- INTERDIT : `Core`, `configs`, `web_layer` ❌
+
+**`helix.go` à la racine (package `helix`) :**
+- Ce fichier déclare les types marqueurs qui seront utilisés dans les stories suivantes
+- À ce stade : contenu minimal, juste `package helix` avec commentaire de package
+- Ne PAS implémenter `helix.Run()` ici — c'est la Story 1.7
+
+**`doc.go` dans chaque package :**
+```go
+// Package core provides the dependency injection container and lifecycle management
+// for the Helix framework.
+package core
+```
+
+**Règle d'import stricte (à respecter dès le début) :**
+- `core/` : ZÉRO import d'autres packages Helix
+- `config/` : ZÉRO import d'autres packages Helix
+- `web/internal/` : seul endroit autorisé à importer `gofiber/fiber` (pas encore ajouté à ce stade)
+
+### Configuration `.golangci.yml`
+
+```yaml
+run:
+  go: "1.21"
+  timeout: 5m
+
+linters:
+  enable:
+    - govet
+    - staticcheck
+    - errcheck
+    - gofumpt
+    - revive
+    - unused
+
+linters-settings:
+  gofumpt:
+    extra-rules: true
+```
+
+### Pipeline CI `.github/workflows/ci.yml`
+
+```yaml
+name: CI
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint-test-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.21"
+      - name: Lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+      - name: Test
+        run: go test ./...
+      - name: Build
+        run: go build ./...
+```
+
+### Project Structure Notes
+
+- Cette story ne crée QUE la structure et l'outillage — aucune logique métier
+- La story 1.2 créera les interfaces publiques dans `core/`
+- La story 1.7 créera `helix.Run()` et les marqueurs de composants dans `helix.go`
+- Les dépendances Go (`fiber`, `gorm`, `viper`) ne sont PAS ajoutées dans cette story
+
+### Alignement avec Architecture
+
+- Structure conforme à [Source: `_bmad-output/planning-artifacts/architecture.md` — Section "Arborescence Complète du Projet"]
+- Frontières d'import documentées dans [Source: `_bmad-output/planning-artifacts/architecture.md` — Section "Frontières Architecturales"]
+- Outillage CI conforme aux décisions de [Source: `_bmad-output/planning-artifacts/architecture.md` — Section "Fondations du Projet & Outillage"]
+
+### References
+
+- [Source: `_bmad-output/planning-artifacts/epics.md` — Story 1.1 Acceptance Criteria]
+- [Source: `_bmad-output/planning-artifacts/architecture.md` — Section "Fondations du Projet & Outillage"]
+- [Source: `_bmad-output/planning-artifacts/architecture.md` — Section "Arborescence Complète du Projet"]
+- [Source: `_bmad-output/planning-artifacts/architecture.md` — Section "Patterns d'Implémentation & Règles de Cohérence" — Naming Patterns]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Claude Sonnet 4.6 (claude-sonnet-4.6)
+
+### Debug Log References
+
+### Completion Notes List
+
+### File List

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -36,7 +36,6 @@
 
 generated: 2026-04-14
 last_updated: 2026-04-14
-project: helix
 project_key: NOKEY
 tracking_system: file-system
 story_location: _bmad-output/implementation-artifacts
@@ -46,8 +45,8 @@ development_status:
   # ─────────────────────────────────────────────
   # Epic 1: Application Bootstrap & DI Container
   # ─────────────────────────────────────────────
-  epic-1: backlog
-  1-1-initialisation-du-projet-structure-de-base: backlog
+  epic-1: in-progress
+  1-1-initialisation-du-projet-structure-de-base: ready-for-dev
   1-2-interfaces-publiques-du-conteneur-di: backlog
   1-3-reflectresolver-enregistrement-resolution-singleton: backlog
   1-4-detection-des-cycles-de-dependances: backlog


### PR DESCRIPTION
This pull request sets up foundational project documentation, conventions, and automation for the Helix Go framework before any source code is written. It introduces comprehensive guidelines for project structure, commit formatting, GitHub issue integration, and CI tooling, as well as the initial planning artifacts for the first development story. The most important changes are grouped below.

**Project Documentation and Conventions**

* Added `AGENTS.md` detailing the current planning phase, sources of truth, Go module/tooling rules, package hierarchy, DI architecture, and BMad methodology conventions.
* Added `.github/copilot-instructions.md` to instruct Copilot on the planned architecture, package layout, design principles, and Go usage guidelines for Helix.
* Updated `CLAUDE.md` to require strict conventional commit messages and document the process for closing GitHub issues when stories are marked as done.
* Updated `.claude/skills/bmad-dev-story/workflow.md` to enforce conventional commit formatting during story completion.

**GitHub Project and Issue Automation**

* Added instructions in `.claude/skills/bmad-code-review/steps/step-04-present.md` to automatically close related GitHub issues (and update the linked project task) when a story reaches the `done` status, including the search and close commands.

**Sprint and Story Planning Artifacts**

* Added `_bmad-output/implementation-artifacts/1-1-initialisation-du-projet-structure-de-base.md`, specifying acceptance criteria, tasks, and critical rules for initializing the project structure, Go module, and CI.
* Updated `_bmad-output/implementation-artifacts/sprint-status.yaml` to mark Epic 1 as in-progress and Story 1.1 as ready-for-dev, reflecting the current sprint status.
* Removed the unused `project` field from `sprint-status.yaml` for clarity.…artefacts de sprint