### PR TITLE
fix(docs): add base path for GitHub Pages

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitepress'
 
 export default defineConfig({
   title: 'Helix',
+  base: '/helix/',
   description: 'The Spring Boot-inspired Go backend framework. DI/IoC, convention routing, auto-configuration, JWT security, Prometheus metrics — production-ready defaults, zero magic.',
   lang: 'en-US',
 


### PR DESCRIPTION
Add `base: '/helix/'` to VitePress config so assets and links resolve correctly when deployed at `enokdev.github.io/helix/`.

Without this, all CSS/JS assets load from `/assets/...` instead of `/helix/assets/...` → blank page with no styles.